### PR TITLE
Updated required django-crispy-form version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     license="MIT",
     version=VERSION,
     packages=["crispy_bootstrap4"],
-    install_requires=["django-crispy-forms>=1.14.0", "django>=3.2"],
+    install_requires=["django-crispy-forms>=2.0", "django>=3.2"],
     python_requires=">=3.7",
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
Before this gets released we need to bump the minimum version. 

However, to do that we need to have published a new version of django-crispy-forms core.