### PR TITLE
Removed test depedant upon bootstrap3 template pack

### DIFF
--- a/tests/test_form_helper.py
+++ b/tests/test_form_helper.py
@@ -632,6 +632,7 @@ def test_form_group_with_form_inline_bs4():
     html = render_crispy_form(form)
     assert '<div class="form-group row">' not in html
 
+
 def test_passthrough_context():
     """
     Test to ensure that context is passed through implicitly from outside of

--- a/tests/test_form_helper.py
+++ b/tests/test_form_helper.py
@@ -632,15 +632,6 @@ def test_form_group_with_form_inline_bs4():
     html = render_crispy_form(form)
     assert '<div class="form-group row">' not in html
 
-
-def test_template_pack_bs4():
-    form = SampleForm()
-    form.helper = FormHelper()
-    form.helper.template_pack = "bootstrap3"
-    html = render_crispy_form(form)
-    assert "controls" in html  # controls is bootstrap3 only
-
-
 def test_passthrough_context():
     """
     Test to ensure that context is passed through implicitly from outside of

--- a/tests/test_layout_objects.py
+++ b/tests/test_layout_objects.py
@@ -123,7 +123,6 @@ def test_remove_labels():
 
 class TestBootstrapLayoutObjects:
     def test_custom_django_widget(self, settings):
-
         # Make sure an inherited RadioSelect gets rendered as it
         form = SampleFormCustomWidgets()
         assert isinstance(form.fields["inline_radios"].widget, CustomRadioSelect)


### PR DESCRIPTION
The template packs should be standalone. Testing switching template packs should be a feature of core crispy-forms not individual template packs.