### PR TITLE
Updated tox matrix to test against crispy-forms 2.0+

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,9 @@ max_line_length=118
 
 [tox]
 envlist =
-    {py37,py38,py39,py310}-django{32}-crispy{1,-latest},
-    {py38,py39,py310}-django{40,41,42,-latest}-crispy{1,-latest},
-    {py311}-django{41,42,-latest}-crispy{1,-latest},
+    {py37,py38,py39,py310}-django{32}-crispy{2,-latest},
+    {py38,py39,py310}-django{40,41,42,-latest}-crispy{2,-latest},
+    {py311}-django{41,42,-latest}-crispy{2,-latest},
     lint
 
 [testenv]
@@ -14,7 +14,7 @@ deps =
     django40: django>=4.0a,<4.1
     django41: django>=4.1a,<4.2
     django42: django>=4.2,<5.0
-    crispy1: django-crispy-forms<=2.0
+    crispy2: django-crispy-forms>=2.0
     crispy-latest: https://github.com/django-crispy-forms/django-crispy-forms/archive/main.tar.gz
     -rrequirements/testing.txt
 commands = python -W error::DeprecationWarning -W error::PendingDeprecationWarning -m pytest {posargs}


### PR DESCRIPTION
Instead of testing against crispy forms v1 and latest from GitHub we should now test against v2 from PyPI and latest from GitHub. 

I did consider if we could go down to a single version, but I think there's still value in continuing to test against the latest commit on crispy-forms core. 