### PR TITLE
Update field.html to add |safe template tag

### DIFF
--- a/crispy_bootstrap4/templates/bootstrap4/field.html
+++ b/crispy_bootstrap4/templates/bootstrap4/field.html
@@ -13,7 +13,7 @@
         {% if field.label and not field|is_checkbox and form_show_labels %}
         {# not field|is_radioselect in row below can be removed once Django 3.2 is no longer supported #}    
         <label {% if field.id_for_label and not field|is_radioselect %}for="{{ field.id_for_label }}" {% endif %}class="{% if 'form-horizontal' in form_class %}col-form-label {% endif %}{{ label_class }}{% if field.field.required %} requiredField{% endif %}">
-                {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+                {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
             </label>
         {% endif %}
 


### PR DESCRIPTION
field.label was no longer marked as 'safe', preventing the use of html content in model's verbose_name definition