### PR TITLE
2023.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,12 @@
 # CHANGELOG FOR CRISPY-BOOTSTRAP4
 
-## 2023.2
+## 2023.1 (2023-10-16)
 
+* Confirmed support for Django 4.2.
 * Dropped support for Django 3.2, 4.0 and 4.1.
 * Added support for Django 5.0.
 * Added support for Python 3.12.
 * Dropped support for django-crispy-forms 1.x.
-
-## 2023.1
-
-* Confirmed support for Django 4.2.
 
 ## 2022.1
 


### PR DESCRIPTION
Apparently I never did push a 2023.1 release to PyPI despite bumping the version earlier in the year. 

https://github.com/django-crispy-forms/crispy-bootstrap4/blob/5a2e8dee7c1952b063a68711376827183bc6db0a/setup.py#L5

So I think all that's needed to publish a new release is to update the changelog to reflect that. 