### PR TITLE
Update field.html to enable the use of custom-controls on checkbox inputs when show_form_labels is False

### DIFF
--- a/crispy_bootstrap4/templates/bootstrap4/field.html
+++ b/crispy_bootstrap4/templates/bootstrap4/field.html
@@ -26,8 +26,8 @@
         {% endif %}
 
         {% if not field|is_checkboxselectmultiple and not field|is_radioselect %}
-            {% if field|is_checkbox and form_show_labels %}
-                {%if use_custom_control%}
+            {% if field|is_checkbox %}
+                {% if use_custom_control %}
                     {% if field.errors %}
                         {% crispy_field field 'class' 'custom-control-input is-invalid' %}
                     {% else %}
@@ -40,9 +40,11 @@
                         {% crispy_field field 'class' 'form-check-input' %}
                     {% endif %}
                 {% endif %}
+                {% if form_show_labels %}
                 <label for="{{ field.id_for_label }}" class="{%if use_custom_control%}custom-control-label{% else %}form-check-label{% endif %}{% if field.field.required %} requiredField{% endif %}">
                     {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
                 </label>
+                {% endif %}
                 {% include 'bootstrap4/layout/help_text_and_errors.html' %}
             {% elif field|is_file and use_custom_control  %}
                 {% include 'bootstrap4/layout/field_file.html' %}

--- a/crispy_bootstrap4/templates/bootstrap4/field.html
+++ b/crispy_bootstrap4/templates/bootstrap4/field.html
@@ -11,7 +11,7 @@
     {% endif %}
     <{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" class="{% if not field|is_checkbox %}form-group{% if 'form-horizontal' in form_class %} row{% endif %}{% else %}{%if use_custom_control%}{% if tag != 'td' %}custom-control {%endif%} custom-checkbox{% else %}form-check{% endif %}{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
         {% if field.label and not field|is_checkbox and form_show_labels %}
-        {# not field|is_radioselect in row below can be removed once Django 3.2 is no longer supported #}    
+        {# not field|is_radioselect in row below can be removed once Django 3.2 is no longer supported #}
         <label {% if field.id_for_label and not field|is_radioselect %}for="{{ field.id_for_label }}" {% endif %}class="{% if 'form-horizontal' in form_class %}col-form-label {% endif %}{{ label_class }}{% if field.field.required %} requiredField{% endif %}">
                 {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
             </label>
@@ -28,6 +28,10 @@
         {% if not field|is_checkboxselectmultiple and not field|is_radioselect %}
             {% if field|is_checkbox %}
                 {% if use_custom_control %}
+                    {% if tag == 'td' %}
+                        <div class="custom-control custom-checkbox">
+                    {% endif %}
+
                     {% if field.errors %}
                         {% crispy_field field 'class' 'custom-control-input is-invalid' %}
                     {% else %}
@@ -40,12 +44,17 @@
                         {% crispy_field field 'class' 'form-check-input' %}
                     {% endif %}
                 {% endif %}
-                {% if form_show_labels %}
                 <label for="{{ field.id_for_label }}" class="{%if use_custom_control%}custom-control-label{% else %}form-check-label{% endif %}{% if field.field.required %} requiredField{% endif %}">
-                    {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+                    {% if form_show_labels %}
+                        {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+                    {% else %}
+                        &nbsp;
+                    {% endif %}
                 </label>
-                {% endif %}
                 {% include 'bootstrap4/layout/help_text_and_errors.html' %}
+                {% if use_custom_control and tag == 'td' %}
+                    </div>
+                {% endif %}
             {% elif field|is_file and use_custom_control  %}
                 {% include 'bootstrap4/layout/field_file.html' %}
             {% else %}
@@ -57,13 +66,13 @@
                             {% crispy_field field 'class' 'custom-select' %}
                         {% endif %}
                     {% elif field|is_file %}
-                        {% if field.errors %}                 
+                        {% if field.errors %}
                             {% crispy_field field 'class' 'form-control-file is-invalid' %}
                         {% else %}
                             {% crispy_field field 'class' 'form-control-file' %}
                         {% endif %}
                     {% else %}
-                        {% if field.errors %}                      
+                        {% if field.errors %}
                             {% crispy_field field 'class' 'form-control is-invalid' %}
                         {% else %}
                             {% crispy_field field 'class' 'form-control' %}

--- a/tests/results/bootstrap4/test_layout/test_inline_formset_checkbox.html
+++ b/tests/results/bootstrap4/test_layout/test_inline_formset_checkbox.html
@@ -22,7 +22,7 @@
             <div class="form-group">
                 <td id="div_id_form-__prefix__-box_one" class="custom-checkbox">
                     <div>
-                        <input type="checkbox" name="form-__prefix__-box_one" class="checkboxinput form-control"
+                        <input type="checkbox" name="form-__prefix__-box_one" class="checkboxinput custom-control-input"
                                id="id_form-__prefix__-box_one">
                     </div>
                 </td>
@@ -30,7 +30,7 @@
             <div class="form-group">
                 <td id="div_id_form-__prefix__-box_two" class="custom-checkbox">
                     <div>
-                        <input type="checkbox" name="form-__prefix__-box_two" class="checkboxinput form-control"
+                        <input type="checkbox" name="form-__prefix__-box_two" class="checkboxinput custom-control-input"
                                id="id_form-__prefix__-box_two">
                     </div>
                 </td>
@@ -40,7 +40,7 @@
             <div class="form-group">
                 <td id="div_id_form-0-box_one" class="custom-checkbox">
                     <div>
-                        <input type="checkbox" name="form-0-box_one" class="checkboxinput form-control"
+                        <input type="checkbox" name="form-0-box_one" class="checkboxinput custom-control-input"
                                id="id_form-0-box_one">
                     </div>
                 </td>
@@ -48,7 +48,7 @@
             <div class="form-group">
                 <td id="div_id_form-0-box_two" class="custom-checkbox">
                     <div>
-                        <input type="checkbox" name="form-0-box_two" class="checkboxinput form-control"
+                        <input type="checkbox" name="form-0-box_two" class="checkboxinput custom-control-input"
                                id="id_form-0-box_two">
                     </div>
                 </td>

--- a/tests/results/bootstrap4/test_layout/test_inline_formset_checkbox.html
+++ b/tests/results/bootstrap4/test_layout/test_inline_formset_checkbox.html
@@ -21,28 +21,40 @@
         <tr class="d-none empty-form">
             <div class="form-group">
                 <td id="div_id_form-__prefix__-box_one" class="custom-checkbox">
-                    <input type="checkbox" name="form-__prefix__-box_one" class="checkboxinput custom-control-input"
-                               id="id_form-__prefix__-box_one">
+                    <div class="custom-control custom-checkbox">
+                        <input type="checkbox" name="form-__prefix__-box_one" class="checkboxinput custom-control-input"
+                                id="id_form-__prefix__-box_one">
+                        <label for="id_form-__prefix__-box_one" class="custom-control-label requiredField">&nbsp;</label>
+                    </div>
                 </td>
             </div>
             <div class="form-group">
                 <td id="div_id_form-__prefix__-box_two" class="custom-checkbox">
-                    <input type="checkbox" name="form-__prefix__-box_two" class="checkboxinput custom-control-input"
-                               id="id_form-__prefix__-box_two">
+                    <div class="custom-control custom-checkbox">
+                        <input type="checkbox" name="form-__prefix__-box_two" class="checkboxinput custom-control-input"
+                                id="id_form-__prefix__-box_two">
+                        <label for="id_form-__prefix__-box_two" class="custom-control-label requiredField">&nbsp;</label>
+                    </div>
                 </td>
             </div>
         </tr>
         <tr>
             <div class="form-group">
                 <td id="div_id_form-0-box_one" class="custom-checkbox">
-                    <input type="checkbox" name="form-0-box_one" class="checkboxinput custom-control-input"
-                               id="id_form-0-box_one">
+                    <div class="custom-control custom-checkbox">
+                        <input type="checkbox" name="form-0-box_one" class="checkboxinput custom-control-input"
+                                id="id_form-0-box_one">
+                        <label for="id_form-0-box_one" class="custom-control-label requiredField">&nbsp;</label>
+                    </div>
                 </td>
             </div>
             <div class="form-group">
                 <td id="div_id_form-0-box_two" class="custom-checkbox">
-                    <input type="checkbox" name="form-0-box_two" class="checkboxinput custom-control-input"
-                               id="id_form-0-box_two">
+                    <div class="custom-control custom-checkbox">
+                        <input type="checkbox" name="form-0-box_two" class="checkboxinput custom-control-input"
+                                id="id_form-0-box_two">
+                        <label for="id_form-0-box_two" class="custom-control-label requiredField">&nbsp;</label>
+                    </div>
                 </td>
             </div>
         </tr>

--- a/tests/results/bootstrap4/test_layout/test_inline_formset_checkbox.html
+++ b/tests/results/bootstrap4/test_layout/test_inline_formset_checkbox.html
@@ -21,36 +21,28 @@
         <tr class="d-none empty-form">
             <div class="form-group">
                 <td id="div_id_form-__prefix__-box_one" class="custom-checkbox">
-                    <div>
-                        <input type="checkbox" name="form-__prefix__-box_one" class="checkboxinput custom-control-input"
+                    <input type="checkbox" name="form-__prefix__-box_one" class="checkboxinput custom-control-input"
                                id="id_form-__prefix__-box_one">
-                    </div>
                 </td>
             </div>
             <div class="form-group">
                 <td id="div_id_form-__prefix__-box_two" class="custom-checkbox">
-                    <div>
-                        <input type="checkbox" name="form-__prefix__-box_two" class="checkboxinput custom-control-input"
+                    <input type="checkbox" name="form-__prefix__-box_two" class="checkboxinput custom-control-input"
                                id="id_form-__prefix__-box_two">
-                    </div>
                 </td>
             </div>
         </tr>
         <tr>
             <div class="form-group">
                 <td id="div_id_form-0-box_one" class="custom-checkbox">
-                    <div>
-                        <input type="checkbox" name="form-0-box_one" class="checkboxinput custom-control-input"
+                    <input type="checkbox" name="form-0-box_one" class="checkboxinput custom-control-input"
                                id="id_form-0-box_one">
-                    </div>
                 </td>
             </div>
             <div class="form-group">
                 <td id="div_id_form-0-box_two" class="custom-checkbox">
-                    <div>
-                        <input type="checkbox" name="form-0-box_two" class="checkboxinput custom-control-input"
+                    <input type="checkbox" name="form-0-box_two" class="checkboxinput custom-control-input"
                                id="id_form-0-box_two">
-                    </div>
                 </td>
             </div>
         </tr>


### PR DESCRIPTION
The current code prevents the display of checkboxes (single) as BS4 custom-controls if show_form_labels is False. This modification moves the control of the label display around the label block itself allowing the display of checkboxes as custom-control regardless of the value of show_form_labels.